### PR TITLE
fix: scroll menu with whole page

### DIFF
--- a/public/css/styling.css
+++ b/public/css/styling.css
@@ -324,7 +324,7 @@ footer a:hover {
 
 .page-header-menu-container {
   display: none;
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   right: 0;
@@ -434,7 +434,7 @@ footer a:hover {
 }
 
 .page-header-menu-close {
-  position: fixed;
+  position: absolute;
   z-index: 5;
   right: 35px;
   top: 20px;
@@ -476,6 +476,10 @@ footer a:hover {
     display: grid;
   }
 
+  .page-header-menu-container {
+    position: fixed;
+  }
+
   .page-header-social-media-icons-container .page-header-social-media-icons {
     display: none;
   }
@@ -512,5 +516,6 @@ footer a:hover {
 
   .page-header-menu-close {
     right: 25px;
+    position: fixed;
   }
 }

--- a/views/includes/header.pug
+++ b/views/includes/header.pug
@@ -1,5 +1,5 @@
 header.page-header
-	a.page-header-logo
+	a(href="https://bitcoinvault.global").page-header-logo
 		img.page-header-logo-without-text(src="/img/header/btcv-logo.svg" alt="logo")
 		img.page-header-logo-with-text(src="/img/header/btcv-logo-with-text.svg" alt="logo")
 	


### PR DESCRIPTION
This fix is mainly focused on changing the scrolling behaviour of menu. Now on mobile view menu scrolls with whole page. Additionally logo from now on will redirect to https://bitcoinvault.global/.